### PR TITLE
Adds a help command and an unrecognized command message.

### DIFF
--- a/server/connect/main/main.go
+++ b/server/connect/main/main.go
@@ -70,6 +70,11 @@ func main() {
 				fmt.Println("Stopping...")
 				closeAll()
 				return
+			} else if str == "help\n" {
+				fmt.Println("LilyPad Connect - Help")
+				fmt.Println("reload - Reloads the connect.yml")
+				fmt.Println("debug  - Prints out CPU, Memory, and Routine stats")
+				fmt.Println("stop   - Stops the process. (Aliases: 'exit', 'halt')")
 			} else {
 				fmt.Println("Command not found. Use \"help\" to view available commands.")
 			}

--- a/server/proxy/main/main.go
+++ b/server/proxy/main/main.go
@@ -88,6 +88,11 @@ func main() {
 				fmt.Println("Stopping...")
 				closeAll()
 				return
+			} else if str == "help\n" {
+				fmt.Println("LilyPad Proxy - Help")
+				fmt.Println("reload - Reloads the connect.yml")
+				fmt.Println("debug  - Prints out CPU, Memory, and Routine stats")
+				fmt.Println("stop   - Stops the process. (Aliases: 'exit', 'halt')")
 			} else {
 				fmt.Println("Command not found. Use \"help\" to view available commands.")
 			}


### PR DESCRIPTION
This commit adds one command to both the server proxy and server connect and also adds an unrecognized command message should the command not fall under any of the above criteria.

The help message does not contain help as a command and contains the debug, reload, and stop commands. It also lists aliases for the commands in an easy to read manner.

The unrecognized command does not print out the command that was typed. If this is requested as a feature or commented on that it should be added, I can plop it into another commit and append it to the pull request if needed.
