### PR TITLE
Changed proxy help menu to reflect proper configuration

### DIFF
--- a/server/proxy/main/main.go
+++ b/server/proxy/main/main.go
@@ -91,7 +91,7 @@ func main() {
 				return
 			} else if str == "help" {
 				fmt.Println("LilyPad Proxy - Help")
-				fmt.Println("reload - Reloads the connect.yml")
+				fmt.Println("reload - Reloads the proxy.yml")
 				fmt.Println("debug  - Prints out CPU, Memory, and Routine stats")
 				fmt.Println("stop   - Stops the process. (Aliases: 'exit', 'halt')")
 			} else {


### PR DESCRIPTION
Currently, the proxy server's help menu states that it reloads the connect.yml, while it in fact reloads the proxy.yml configuration.
