### PR TITLE
Changes code markdown from inline to fences, makes it look nicer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,27 @@ Compilation
 
 You can currently compile either Server Proxy or Server Connect.
 
-1) Pull the project: `go get github.com/LilyPad/GoLilyPad`
-
-2) Dependencies: `go get launchpad.net/goyaml`
+Pull the project and get the dependencies:
+```bash
+$ go get github.com/LilyPad/GoLilyPad
+$ go get launchpad.net/goyaml
+```
 
 ### Server Connect ###
 
-3.A) `cd $GOPATH/pkg/github.com/LilyPad/GoLilyPad/server/connect/main`
+```bash
+$ cd $GOPATH/pkg/github.com/LilyPad/GoLilyPad/server/connect/main
+```
 
 ### Server Proxy ###
 
-3.B) `cd $GOPATH/pkg/github.com/LilyPad/GoLilyPad/server/proxy/main`
+```bash
+$ cd $GOPATH/pkg/github.com/LilyPad/GoLilyPad/server/proxy/main
+```
 
 ### Lastly ###
 
-4) `go build`
-
-5) `./main`
+```bash
+$ go build
+$ ./main
+```


### PR DESCRIPTION
This commit basically fixes up the ugly README. The inline code swatches weren't exactly easy to read, nor did they go along with the Github markdown - where you can utilize code fences to not only allow for code padding but also syntax highlighting. With this, I added $'s in front of each command, which symbolizes that it should be run as a user.

The commit also removes the very hard to understand numbered steps during the compilation process. For example, nobody can tell what the difference between 3a and 3b is - if you look at the code you can, but it doesn't state anywhere you shouldn't run them both.

Heres an example of the code inline -> fence change:
`go get launchpad.net/yaml`

``` bash
$ go get launchpad.net/yaml
```

Doesn't that look much nicer?
