### PR TITLE
Add ability to set the sample per route

### DIFF
--- a/server/proxy/main/config/config.go
+++ b/server/proxy/main/config/config.go
@@ -86,6 +86,26 @@ func (this *Config) RouteIcons(domain string) []string {
 	return []string{"server-icon.png"};
 }
 
+func (this *Config) RouteSample(domain string) string {
+	this.Proxy.routesMutex.Lock()
+	if this.Proxy.routes == nil {
+		this.Proxy.routes = make(map[string]ConfigProxyRoute);
+		for _, route := range this.Proxy.Routes {
+			this.Proxy.routes[strings.ToLower(route.Domain)] = route
+		}
+	}
+	this.Proxy.routesMutex.Unlock()
+	if route, ok := this.Proxy.routes[strings.ToLower(domain)]; ok {
+		if route.Sample != "" {
+			return route.Sample
+		}
+	}
+	if domain != "" {
+		return this.RouteSample("")
+	}
+	return "sample.txt";
+}
+
 func (this *Config) LocaleFull() string {
 	return this.Proxy.Locale.Full
 }
@@ -143,6 +163,7 @@ type ConfigProxyRoute struct {
 	Motds []string `yaml:"motds,omitempty"`
 	Icon string `yaml:"icon,omitempty"`
 	Icons []string `yaml:"icons,omitempty"`
+	Sample string `yaml:"sample,omitempty"`
 }
 
 func DefaultConfig() (config *Config) {
@@ -157,10 +178,10 @@ func DefaultConfig() (config *Config) {
 		Proxy: ConfigProxy{
 			Bind: ":25565",
 			Routes: []ConfigProxyRoute{
-				ConfigProxyRoute{"", "example", nil, "", nil, "", nil},
-				ConfigProxyRoute{"example.com", "", []string{"hub1", "hub2"}, "Example Custom MOTD", nil, "", nil},
-				ConfigProxyRoute{"hub.example.com", "hub", nil, "", []string{"Example MOTD 1", "Example MOTD 2"}, "", nil},
-				ConfigProxyRoute{"icon.example.com", "hub", nil, "", nil, "icon.png", []string{"icon1.png", "icon2.png", "icons/icon3.png"}},
+				ConfigProxyRoute{"", "example", nil, "", nil, "", nil, ""},
+				ConfigProxyRoute{"example.com", "", []string{"hub1", "hub2"}, "Example Custom MOTD", nil, "", nil, ""},
+				ConfigProxyRoute{"hub.exmaple.com", "hub", nil, "", []string{"Example MOTD 1", "Example MOTD 2"}, "", nil, ""},
+				ConfigProxyRoute{"icon.exmaple.com", "hub", nil, "", nil, "icon.png", []string{"icon1.png", "icon2.png", "icons/icon3.png"}, ""},
 			},
 			Locale: ConfigProxyLocale{
 				Full: "The server seems to be currently full. Try again later!",

--- a/server/proxy/router.go
+++ b/server/proxy/router.go
@@ -4,4 +4,5 @@ type Router interface {
 	Route(domain string) (servers []string)
 	RouteMotds(domain string) (motds []string)
 	RouteIcons(domain string) (iconPath []string)
+	RouteSample(domain string) (samplePath string)
 }

--- a/server/proxy/session.go
+++ b/server/proxy/session.go
@@ -196,10 +196,11 @@ func (this *Session) HandlePacket(packet packet.Packet) (err error) {
 		}
 	case STATE_STATUS:
 		if packet.Id() == minecraft.PACKET_SERVER_STATUS_REQUEST {
+			samplePath := this.server.Router().RouteSample(this.serverAddress)
+			sampleTxt, sampleErr := ioutil.ReadFile(samplePath)
 			icons := this.server.Router().RouteIcons(this.serverAddress)
 			iconPath := icons[RandomInt(len(icons))]
 			favicon, faviconErr := ioutil.ReadFile(iconPath)
-			sampleTxt, sampleErr := ioutil.ReadFile("sample.txt")
 			var faviconString string
 			if faviconErr == nil {
 				faviconString = "data:image/png;base64," + base64.StdEncoding.EncodeToString(favicon)


### PR DESCRIPTION
Currently there is no way to set different player samples per route.
This PR add the ability to set the path to a txt file containing the desired sample for the route.

```
  - domain: example.com
    servers:
    - hub1
    - hub2
    motd: Example Custom MOTD
    sample: exampleSample.txt
  - domain: hub.exmaple.com
    server: hub
    motds:
    - Example MOTD 1
    - Example MOTD 2
    sample: hubSample.txt
```

If no sample is set for the route it will try get the sample from the root route. And if no sample is set for the root route it will use "sample.txt" to keep backwards compatibility. 
