### PR TITLE
Update the version to 1.7.10

### DIFF
--- a/packet/minecraft/constants.go
+++ b/packet/minecraft/constants.go
@@ -3,7 +3,7 @@ package minecraft
 import "github.com/LilyPad/GoLilyPad/packet"
 
 const (
-	STRING_VERSION = string("1.7.6")
+	STRING_VERSION = string("1.7.10")
 	MAGIC = string("§")
 
 	PACKET_SERVER_HANDSHAKE = 0x00


### PR DESCRIPTION
This will show on minecraft server lists as 1.7.10, as well as outdated clients.
