### PR TITLE
Prevent a server crash if an error occurs.

### DIFF
--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -57,7 +57,8 @@ func (this *Server) ListenAndServe(addr string) (err error) {
 	for {
 		conn, err = this.listener.Accept()
 		if err != nil {
-			return
+			fmt.Println("Error listener:", err)
+			continue
 		}
 		NewSession(this, conn).Serve()
 	}


### PR DESCRIPTION
When an error occurs in the main goroutine, the whole proxy will crash :) 
Ex: Too many open files error