### PR TITLE
Ignore EOF error on readstring

### DIFF
--- a/server/connect/main/main.go
+++ b/server/connect/main/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"fmt"
 	"os"
 	"runtime"
@@ -31,6 +32,9 @@ func main() {
 		reader := bufio.NewReader(os.Stdin)
 		for {
 			str, err := reader.ReadString('\n')
+			if err == io.EOF {
+				continue
+			}
 			if err != nil {
 				stdinErr <- err
 			}

--- a/server/proxy/main/main.go
+++ b/server/proxy/main/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"fmt"
 	"os"
 	"runtime"
@@ -33,6 +34,9 @@ func main() {
 		reader := bufio.NewReader(os.Stdin)
 		for {
 			str, err := reader.ReadString('\n')
+			if err == io.EOF {
+				continue
+			}
 			if err != nil {
 				stdinErr <- err
 			}


### PR DESCRIPTION
When running lilypad in docker in detached mode, it always throws an EOF to the app.
Lets ignore this and let the app just run.
