### PR TITLE
reduce cpu load when ignoring EOF spam

### DIFF
--- a/server/connect/main/main.go
+++ b/server/connect/main/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 	"strings"
 	"github.com/LilyPad/GoLilyPad/server/connect"
 	"github.com/LilyPad/GoLilyPad/server/connect/main/config"
@@ -33,6 +34,7 @@ func main() {
 		for {
 			str, err := reader.ReadString('\n')
 			if err == io.EOF {
+				time.Sleep(100*time.Millisecond)
 				continue
 			}
 			if err != nil {

--- a/server/proxy/main/main.go
+++ b/server/proxy/main/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 	"github.com/LilyPad/GoLilyPad/server/proxy"
 	"github.com/LilyPad/GoLilyPad/server/proxy/connect"
 	"github.com/LilyPad/GoLilyPad/server/proxy/main/config"
@@ -35,6 +36,7 @@ func main() {
 		for {
 			str, err := reader.ReadString('\n')
 			if err == io.EOF {
+				time.Sleep(100*time.Millisecond)
 				continue
 			}
 			if err != nil {


### PR DESCRIPTION
When testing, noticed cpu was 100% this is cause EOF is basically spammed and ReadString is constantly being called, so let's sleep it.