### PR TITLE
Fix ServerAddress resolution for 1.8 FML clients

### DIFF
--- a/packet/minecraft/packetServerHandshake.go
+++ b/packet/minecraft/packetServerHandshake.go
@@ -3,6 +3,7 @@ package minecraft
 import (
 	"io"
 	"github.com/LilyPad/GoLilyPad/packet"
+	"strings"
 )
 
 type PacketServerHandshake struct {
@@ -10,6 +11,7 @@ type PacketServerHandshake struct {
 	ServerAddress string
 	ServerPort uint16
 	State int
+	NullAppendedData string
 }
 
 func NewPacketServerHandshake(protocolVersion int, serverAddress string, serverPort uint16, state int) (this *PacketServerHandshake) {
@@ -47,6 +49,14 @@ func (this *packetServerHandshakeCodec) Decode(reader io.Reader, util []byte) (d
 	if err != nil {
 		return
 	}
+
+	// Handling for 1.8 FML appending '\0FML\0' to the host-string
+	idx := strings.Index(packetServerHandshake.ServerAddress, "\x00")
+	if idx != -1 {
+		packetServerHandshake.NullAppendedData = packetServerHandshake.ServerAddress[idx:]
+		packetServerHandshake.ServerAddress = packetServerHandshake.ServerAddress[:idx]
+	}
+
 	decode = packetServerHandshake
 	return
 }


### PR DESCRIPTION
In order to allow for compatibility with vanilla clients, 1.8 FML appends `\0FML\0` to the server address field of the handshake packet so the client type can be detected server side.

As lilypad proxy route determination operates on an exact match for that field, this causes all 1.8 clients with FML installed to be redirected to the default server(s).

As hostnames can't contain null characters, this PR just splits the string on the first occurrence of a null character, and stores the additional data in a new field `NullAppendedData`, rather than discarding it.

Based on SpigotMC/BungeeCord@4809f1f80ace9ae87b91453c8887c70f5e098bd0.