### PR TITLE
Enable compression for 1.8 clients

### DIFF
--- a/server/proxy/session.go
+++ b/server/proxy/session.go
@@ -151,7 +151,7 @@ func (this *Session) SetAuthenticated(result bool) {
 		return
 	}
 	this.state = STATE_INIT
-	if this.protocolVersion >= mc19.VersionNum {
+	if this.protocolVersion >= mc18.VersionNum {
 		this.SetCompression(256)
 	}
 	if this.protocolVersion >= 5 {


### PR DESCRIPTION
Compression is supported on client versions 1.8 and upwards.