### PR TITLE
Implement player network join/leave events

### DIFF
--- a/client/connect/connectImpl.go
+++ b/client/connect/connectImpl.go
@@ -85,6 +85,8 @@ func (this *ConnectImpl) HandlePacket(packet packet.Packet) (err error) {
 		this.DispatchEvent("redirect", WrapEventRedirect(packet.(*connect.PacketRedirectEvent)))
 	case connect.PACKET_SERVER_EVENT:
 		this.DispatchEvent("server", WrapEventServer(packet.(*connect.PacketServerEvent)))
+	case connect.PACKET_PLAYER_EVENT:
+		this.DispatchEvent("player", WrapEventPlayer(packet.(*connect.PacketPlayerEvent)))
 	}
 	return
 }

--- a/client/connect/eventPlayer.go
+++ b/client/connect/eventPlayer.go
@@ -1,0 +1,20 @@
+package connect
+
+import (
+	"github.com/LilyPad/GoLilyPad/packet/connect"
+	"github.com/satori/go.uuid"
+)
+
+type EventPlayer struct {
+	Joining    bool
+	PlayerName string
+	PlayerUUID uuid.UUID
+}
+
+func WrapEventPlayer(packet *connect.PacketPlayerEvent) (this *EventPlayer) {
+	this = new(EventPlayer)
+	this.Joining = packet.Joining
+	this.PlayerName = packet.PlayerName
+	this.PlayerUUID = packet.PlayerUUID
+	return
+}

--- a/packet/connect/constants.go
+++ b/packet/connect/constants.go
@@ -26,6 +26,7 @@ const (
 	PACKET_MESSAGE_EVENT  = 0x03
 	PACKET_REDIRECT_EVENT = 0x04
 	PACKET_SERVER_EVENT   = 0x05
+	PACKET_PLAYER_EVENT   = 0x06
 )
 
 var requestCodecs = []RequestCodec{
@@ -61,4 +62,5 @@ var PacketCodec = packet.NewPacketCodecRegistry([]packet.PacketCodec{
 	PACKET_MESSAGE_EVENT:  new(packetMessageEventCodec),
 	PACKET_REDIRECT_EVENT: new(packetRedirectEventCodec),
 	PACKET_SERVER_EVENT:   new(packetServerEventCodec),
+	PACKET_PLAYER_EVENT:   new(packetPlayerEventCodec),
 })

--- a/packet/connect/packetPlayerEvent.go
+++ b/packet/connect/packetPlayerEvent.go
@@ -1,0 +1,69 @@
+package connect
+
+import (
+	"github.com/LilyPad/GoLilyPad/packet"
+	"io"
+	"github.com/satori/go.uuid"
+)
+
+type PacketPlayerEvent struct {
+	Joining    bool
+	PlayerName string
+	PlayerUUID uuid.UUID
+}
+
+func NewPacketPlayerEventJoin(playerName string, playerUUID uuid.UUID) (this *PacketPlayerEvent) {
+	this = new(PacketPlayerEvent)
+	this.Joining = true
+	this.PlayerName = playerName
+	this.PlayerUUID = playerUUID
+	return
+}
+
+func NewPacketPlayerEventLeave(playerName string, playerUUID uuid.UUID) (this *PacketPlayerEvent) {
+	this = new(PacketPlayerEvent)
+	this.Joining = false
+	this.PlayerName = playerName
+	this.PlayerUUID = playerUUID
+	return
+}
+
+func (this *PacketPlayerEvent) Id() int {
+	return PACKET_PLAYER_EVENT
+}
+
+type packetPlayerEventCodec struct {
+}
+
+func (this *packetPlayerEventCodec) Decode(reader io.Reader) (decode packet.Packet, err error) {
+	packetPlayerEvent := new(PacketPlayerEvent)
+	packetPlayerEvent.Joining, err = packet.ReadBool(reader)
+	if err != nil {
+		return
+	}
+	packetPlayerEvent.PlayerName, err = packet.ReadString(reader)
+	if err != nil {
+		return
+	}
+	packetPlayerEvent.PlayerUUID, err = packet.ReadUUID(reader)
+	if err != nil {
+		return
+	}
+	decode = packetPlayerEvent
+	return
+}
+
+func (this *packetPlayerEventCodec) Encode(writer io.Writer, encode packet.Packet) (err error) {
+	packetPlayerEvent := encode.(*PacketPlayerEvent)
+	err = packet.WriteBool(writer, packetPlayerEvent.Joining)
+	if err != nil {
+		return
+	}
+	err = packet.WriteString(writer, packetPlayerEvent.PlayerName)
+	if err != nil {
+		return
+	}
+	err = packet.WriteUUID(writer, packetPlayerEvent.PlayerUUID)
+	return
+	return
+}

--- a/server/connect/session.go
+++ b/server/connect/session.go
@@ -270,6 +270,8 @@ func (this *Session) HandlePacket(packet packet.Packet) (err error) {
 			}
 		case connect.REQUEST_NOTIFY_PLAYER:
 			if this.Authorized() && this.role == ROLE_PROXY {
+				var playerPacket *connect.PacketPlayerEvent
+
 				add := request.(*connect.RequestNotifyPlayer).Add
 				player := request.(*connect.RequestNotifyPlayer).Player
 				uuid := request.(*connect.RequestNotifyPlayer).Uuid
@@ -279,10 +281,18 @@ func (this *Session) HandlePacket(packet packet.Packet) (err error) {
 						break
 					}
 					this.proxyPlayers[player] = uuid
+					playerPacket = connect.NewPacketPlayerEventJoin(player, uuid)
 				} else {
 					if uuid, ok := this.proxyPlayers[player]; ok {
 						this.server.networkCache.RemovePlayer(player, uuid)
 						delete(this.proxyPlayers, player)
+						playerPacket = connect.NewPacketPlayerEventLeave(player, uuid)
+					}
+				}
+				for _, session := range this.server.SessionRegistry(ROLE_AUTHORIZED).GetAll() {
+					err := session.Write(playerPacket)
+					if (err != nil) {
+						fmt.Println(err)
 					}
 				}
 				result = connect.NewResultNotifyPlayer()


### PR DESCRIPTION
Throughout the lifetime of LilyPad, plugins wishing to either track online players or movements throughout the network have (mostly) relies on either polling the connect server, or maintaining local caches, and updating those through message channels.

This PR adds a new event packet to LilyPad which allows any authenticated session to receive network level join and leave events for players.

There's also a corresponding PR for JLilypad to fix handling for the new packet in BukkitConnect