### PR TITLE
Add crude IPv6 fix

### DIFF
--- a/server/proxy/connect/proxyConnect.go
+++ b/server/proxy/connect/proxyConnect.go
@@ -50,7 +50,7 @@ func NewProxyConnect(addr *string, user *string, pass *string, proxy *ProxyConfi
 			if serverEvent.Address == "127.0.0.1" || serverEvent.Address == "localhost" {
 				address, _, _ = net.SplitHostPort(*addr)
 			} else if strings.Contains(serverEvent.Address, ":") {
-				address = "[" + serverEvent.Address "]"
+				address = "[" + serverEvent.Address + "]"
 			} else {
 				address = serverEvent.Address
 			}

--- a/server/proxy/connect/proxyConnect.go
+++ b/server/proxy/connect/proxyConnect.go
@@ -6,6 +6,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -48,6 +49,8 @@ func NewProxyConnect(addr *string, user *string, pass *string, proxy *ProxyConfi
 			var address string
 			if serverEvent.Address == "127.0.0.1" || serverEvent.Address == "localhost" {
 				address, _, _ = net.SplitHostPort(*addr)
+			} else if strings.Contains(serverEvent.Address, ":") {
+				address = "[" + serverEvent.Address "]"
 			} else {
 				address = serverEvent.Address
 			}


### PR DESCRIPTION
Add a crude check to prevent the address from becoming invalid, e.g. turns 2001:db8::1 and port 12345 into 2001:db8::1:12345 which is invalid.

There probably need to be fixes in other places to support IPv6.