### PR TITLE
Add prevent authentication proxy option

### DIFF
--- a/server/proxy/auth/auth.go
+++ b/server/proxy/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 type GameProfile struct {
@@ -18,8 +19,10 @@ type GameProfileProperty struct {
 	Signature string `json:"signature"`
 }
 
-func Authenticate(name string, serverId string, sharedSecret []byte, publicKey []byte) (profile GameProfile, err error) {
-	response, err := http.Get(fmt.Sprintf(URL, name, MojangSha1Hex([]byte(serverId), sharedSecret, publicKey)))
+func Authenticate(name string, serverId string, sharedSecret []byte, publicKey []byte, ip string) (profile GameProfile, err error) {
+	//escape the ip to it correctly parse IPv6 addresses
+	httpUrl := fmt.Sprintf(URL, name, MojangSha1Hex([]byte(serverId), sharedSecret, publicKey), url.QueryEscape(ip))
+	response, err := http.Get(httpUrl)
 	if err != nil {
 		return
 	}

--- a/server/proxy/auth/constants.go
+++ b/server/proxy/auth/constants.go
@@ -1,5 +1,5 @@
 package auth
 
 const (
-	URL = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s"
+	URL = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s&ip=%s"
 )

--- a/server/proxy/session.go
+++ b/server/proxy/session.go
@@ -402,7 +402,7 @@ func (this *Session) HandlePacket(packet packet.Packet) (err error) {
 				return
 			}
 			var authErr error
-			this.profile, authErr = auth.Authenticate(this.name, this.serverId, sharedSecret, this.server.publicKey)
+			this.profile, authErr = auth.Authenticate(this.name, this.serverId, sharedSecret, this.server.publicKey, this.remoteIp)
 			if authErr != nil {
 				this.SetAuthenticated(false)
 				fmt.Println("Proxy server, failed to authorize:", this.name, "ip:", this.remoteIp, "err:", authErr)


### PR DESCRIPTION
A couple of months ago, Mojang introduced a new parameter IP for their session servers. It prevents player connections if someone uses an authentication proxy, but still wants to connect directly to the Spigot server. So it doesn't prevent proxy connections in general.