### PR TITLE
Added login event, moved packet interceptors to registry codec, added api method to get outbridge version

### DIFF
--- a/packet/packetCodecVarIntLength.go
+++ b/packet/packetCodecVarIntLength.go
@@ -9,8 +9,6 @@ import (
 
 type PacketCodecVarIntLength struct {
 	codec           PacketCodec
-	interceptDecode PacketIntercept
-	interceptEncode PacketIntercept
 }
 
 func NewPacketCodecVarIntLength() (this *PacketCodecVarIntLength) {
@@ -37,24 +35,12 @@ func (this *PacketCodecVarIntLength) Decode(reader io.Reader) (packet Packet, er
 		return
 	}
 	packet, err = this.codec.Decode(bytes.NewBuffer(payload))
-	if this.interceptDecode != nil {
-		if err != nil {
-			return
-		}
-		err = this.interceptDecode(packet, bytes.NewBuffer(payload))
-	}
 	return
 }
 
 func (this *PacketCodecVarIntLength) Encode(writer io.Writer, packet Packet) (err error) {
 	buffer := new(bytes.Buffer)
 	err = this.codec.Encode(buffer, packet)
-	if this.interceptEncode != nil {
-		if err != nil {
-			return
-		}
-		err = this.interceptEncode(packet, buffer)
-	}
 	if err != nil {
 		return
 	}
@@ -68,12 +54,4 @@ func (this *PacketCodecVarIntLength) Encode(writer io.Writer, packet Packet) (er
 
 func (this *PacketCodecVarIntLength) SetCodec(codec PacketCodec) {
 	this.codec = codec
-}
-
-func (this *PacketCodecVarIntLength) SetInterceptDecode(intercept PacketIntercept) {
-	this.interceptDecode = intercept
-}
-
-func (this *PacketCodecVarIntLength) SetInterceptEncode(intercept PacketIntercept) {
-	this.interceptEncode = intercept
 }

--- a/server/proxy/api/api.go
+++ b/server/proxy/api/api.go
@@ -25,6 +25,10 @@ type Config interface {
 	Authenticate() bool
 }
 
+type OutBridge interface {
+	Version() *minecraft.Version
+}
+
 type Session interface {
 	Conn() net.Conn
 	Write(packet.Packet, PacketSubject)
@@ -36,6 +40,7 @@ type Session interface {
 	RemoteOverride(ip string, port string)
 	State() SessionState
 	Version() *minecraft.Version
+	OutBridge() OutBridge
 }
 
 type SessionRegistry interface {
@@ -96,6 +101,7 @@ const (
 
 type EventBus interface {
 	HandleSessionOpen(EventSessionHandler)
+	HandleSessionLogin(EventSessionHandler)
 	HandleSessionClose(EventSessionHandler)
 	HandleSessionState(EventSessionHandler)
 	HandleSessionRedirect(EventSessionHandler)
@@ -116,6 +122,13 @@ type EventSessionHandler func(EventSession)
 type EventSessionOpen interface {
 	EventSession
 	EventCancellable
+}
+
+type EventSessionLogin interface {
+	EventSession
+	EventCancellable
+	SetReason(reason string)
+	GetReason() string
 }
 
 type EventSessionClose interface {

--- a/server/proxy/apiEventBus.go
+++ b/server/proxy/apiEventBus.go
@@ -7,6 +7,7 @@ import (
 
 type eventBus struct {
 	sessionOpen        []api.EventSessionHandler
+	sessionLogin       []api.EventSessionHandler
 	sessionClose       []api.EventSessionHandler
 	sessionState       []api.EventSessionHandler
 	sessionRedirect    []api.EventSessionHandler
@@ -17,6 +18,7 @@ type eventBus struct {
 func NewEventBus() *eventBus {
 	this := new(eventBus)
 	this.sessionOpen = make([]api.EventSessionHandler, 0)
+	this.sessionLogin = make([]api.EventSessionHandler, 0)
 	this.sessionClose = make([]api.EventSessionHandler, 0)
 	this.sessionState = make([]api.EventSessionHandler, 0)
 	this.sessionRedirect = make([]api.EventSessionHandler, 0)
@@ -65,6 +67,10 @@ func (this *eventBus) HandleSessionOpen(handler api.EventSessionHandler) {
 	this.sessionOpen = append(this.sessionOpen, handler)
 }
 
+func (this *eventBus) HandleSessionLogin(handler api.EventSessionHandler) {
+	this.sessionLogin = append(this.sessionLogin, handler)
+}
+
 func (this *eventBus) HandleSessionClose(handler api.EventSessionHandler) {
 	this.sessionClose = append(this.sessionClose, handler)
 }
@@ -109,6 +115,19 @@ func (this *eventSessionCancellable) IsCancelled() bool {
 
 type eventSessionOpen struct {
 	eventSessionCancellable
+}
+
+type eventSessionLogin struct {
+	eventSessionCancellable
+	reason string
+}
+
+func (this *eventSessionLogin) SetReason(reason string) {
+	this.reason = reason
+}
+
+func (this *eventSessionLogin) GetReason() string {
+	return this.reason
 }
 
 type eventSessionClose struct {

--- a/server/proxy/apiOutBridge.go
+++ b/server/proxy/apiOutBridge.go
@@ -1,0 +1,13 @@
+package proxy
+
+import "github.com/LilyPad/GoLilyPad/packet/minecraft"
+
+type apiOutBridge struct {
+	session *SessionOutBridge
+}
+
+func (this *apiOutBridge) Version() *minecraft.Version {
+	return this.session.protocol
+}
+
+

--- a/server/proxy/apiSession.go
+++ b/server/proxy/apiSession.go
@@ -60,6 +60,16 @@ func (this *apiSession) Version() *minecraft.Version {
 	return this.session.protocol
 }
 
+func (this *apiSession) OutBridge() api.OutBridge {
+	outBridge := this.session.outBridge
+
+	if outBridge == nil {
+		return nil
+	}
+
+	return outBridge.apiOutBridge
+}
+
 type apiSessionRegistry struct {
 	sessionRegistry *SessionRegistry
 }

--- a/server/proxy/session.go
+++ b/server/proxy/session.go
@@ -160,6 +160,18 @@ func (this *Session) SetAuthenticated(result bool) {
 		this.Disconnect(minecraft.Colorize(this.server.localizer.LocaleFull()))
 		return
 	}
+
+	event := eventSessionLogin{
+		eventSessionCancellable: eventSessionCancellable{eventSession: eventSession{this}},
+		reason: "",
+	}
+	eventBus := this.server.apiEventBus
+	eventBus.fireEventSession(eventBus.sessionLogin, &event)
+	if event.IsCancelled() {
+		this.Disconnect(event.GetReason())
+		return
+	}
+
 	servers := this.server.router.Route(this.serverAddress)
 	activeServers := []string{}
 	for _, serverName := range servers {

--- a/server/proxy/sessionOutBridge.go
+++ b/server/proxy/sessionOutBridge.go
@@ -22,6 +22,7 @@ type SessionOutBridge struct {
 	conn                 net.Conn
 	connCodec            *packet.PacketConnCodec
 	pipeline             *packet.PacketPipeline
+	apiOutBridge         api.OutBridge
 	compressionThreshold int
 
 	remoteIp      string
@@ -36,6 +37,7 @@ func NewSessionOutBridge(session *Session, server *connect.Server, conn net.Conn
 	this.protocol = this.session.protocol
 	this.server = server
 	this.conn = conn
+	this.apiOutBridge = &apiOutBridge{this}
 	this.compressionThreshold = -1
 	this.remoteIp, this.remotePort, _ = net.SplitHostPort(conn.RemoteAddr().String())
 	this.state = STATE_DISCONNECTED


### PR DESCRIPTION
New login event, with following information :
- Session logging in
- Cancelled boolean
- Cancelled reason

Api method session.OutBridge().Version() to get the protocol version used by outbridge
Useful when intercepting packets from outbridge, such as plugin message one

Packet interceptors shouldn't have been in VarInt codec, since this logic is called before handling compression and encryption. Packets would not be "readable" at that state.
Moving it to Registry codec fixes the issue.