### PR TITLE
register client stopSound packet from 1.13

### DIFF
--- a/packet/minecraft/id_map.go
+++ b/packet/minecraft/id_map.go
@@ -130,6 +130,9 @@ type IdMap struct {
 	PlayServerCraftingBookData    int
 	PlayServerAdvancementTab      int
 
+	// 1.13
+	PacketClientStopSound         int
+
 	// Entities
 	EntityArrow         int
 	EntityFishingBobber int

--- a/packet/minecraft/v112/constants.go
+++ b/packet/minecraft/v112/constants.go
@@ -411,6 +411,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13 - unsupported
+	PacketClientStopSound: -1,
 	// 1.14 - unsupported
 	PacketClientUpdateViewDistance: -1,
 	PacketClientEntitySoundEffect:  -1,

--- a/packet/minecraft/v113/constants.go
+++ b/packet/minecraft/v113/constants.go
@@ -239,6 +239,7 @@ var PlayPacketServerCodec = packet.NewPacketCodecRegistryDual([]packet.PacketCod
 	PACKET_CLIENT_FACE_PLAYER:        minecraft.NewPacketGenericCodec(PACKET_CLIENT_FACE_PLAYER, Swappers),
 	PACKET_CLIENT_DECLARE_RECIPES:    minecraft.NewPacketGenericCodec(PACKET_CLIENT_DECLARE_RECIPES, Swappers),
 	PACKET_CLIENT_TAGS:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_TAGS, Swappers),
+	PACKET_CLIENT_STOP_SOUND:         minecraft.NewPacketGenericCodec(PACKET_CLIENT_STOP_SOUND, Swappers),
 }, []packet.PacketCodec{
 	PACKET_SERVER_KEEPALIVE:                 minecraft.NewPacketGenericCodec(PACKET_SERVER_KEEPALIVE, Swappers),
 	PACKET_SERVER_CHAT:                      minecraft.NewPacketGenericCodec(PACKET_SERVER_CHAT, Swappers),
@@ -449,6 +450,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13
+	PacketClientStopSound: PACKET_CLIENT_STOP_SOUND,
 	// 1.14 - unsupported
 	PacketClientUpdateViewDistance: -1,
 	PacketClientEntitySoundEffect:  -1,

--- a/packet/minecraft/v114/constants.go
+++ b/packet/minecraft/v114/constants.go
@@ -250,6 +250,7 @@ var PlayPacketServerCodec = packet.NewPacketCodecRegistryDual([]packet.PacketCod
 	PACKET_CLIENT_FACE_PLAYER:        minecraft.NewPacketGenericCodec(PACKET_CLIENT_FACE_PLAYER, Swappers),
 	PACKET_CLIENT_DECLARE_RECIPES:    minecraft.NewPacketGenericCodec(PACKET_CLIENT_DECLARE_RECIPES, Swappers),
 	PACKET_CLIENT_TAGS:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_TAGS, Swappers),
+	PACKET_CLIENT_STOP_SOUND:         minecraft.NewPacketGenericCodec(PACKET_CLIENT_STOP_SOUND, Swappers),
 	// 1.14
 	PACKET_CLIENT_OPEN_HORSE_WINDOW:          minecraft.NewPacketGenericCodec(PACKET_CLIENT_OPEN_HORSE_WINDOW, Swappers),
 	PACKET_CLIENT_UPDATE_LIGHT:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_UPDATE_LIGHT, Swappers),
@@ -473,6 +474,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13
+	PacketClientStopSound: PACKET_CLIENT_STOP_SOUND,
 	// 1.14
 	PacketClientUpdateViewDistance: PACKET_CLIENT_UPDATE_VIEW_DISTANCE,
 	PacketClientEntitySoundEffect:  PACKET_CLIENT_ENTITY_SOUND_EFFECT,

--- a/packet/minecraft/v115/constants.go
+++ b/packet/minecraft/v115/constants.go
@@ -251,6 +251,7 @@ var PlayPacketServerCodec = packet.NewPacketCodecRegistryDual([]packet.PacketCod
 	PACKET_CLIENT_FACE_PLAYER:        minecraft.NewPacketGenericCodec(PACKET_CLIENT_FACE_PLAYER, Swappers),
 	PACKET_CLIENT_DECLARE_RECIPES:    minecraft.NewPacketGenericCodec(PACKET_CLIENT_DECLARE_RECIPES, Swappers),
 	PACKET_CLIENT_TAGS:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_TAGS, Swappers),
+	PACKET_CLIENT_STOP_SOUND:         minecraft.NewPacketGenericCodec(PACKET_CLIENT_STOP_SOUND, Swappers),
 	// 1.14
 	PACKET_CLIENT_OPEN_HORSE_WINDOW:          minecraft.NewPacketGenericCodec(PACKET_CLIENT_OPEN_HORSE_WINDOW, Swappers),
 	PACKET_CLIENT_UPDATE_LIGHT:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_UPDATE_LIGHT, Swappers),
@@ -474,6 +475,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13
+	PacketClientStopSound: PACKET_CLIENT_STOP_SOUND,
 	// 1.14
 	PacketClientUpdateViewDistance: PACKET_CLIENT_UPDATE_VIEW_DISTANCE,
 	PacketClientEntitySoundEffect:  PACKET_CLIENT_ENTITY_SOUND_EFFECT,

--- a/packet/minecraft/v116/constants.go
+++ b/packet/minecraft/v116/constants.go
@@ -252,6 +252,7 @@ var PlayPacketServerCodec = packet.NewPacketCodecRegistryDual([]packet.PacketCod
 	PACKET_CLIENT_FACE_PLAYER:        minecraft.NewPacketGenericCodec(PACKET_CLIENT_FACE_PLAYER, Swappers),
 	PACKET_CLIENT_DECLARE_RECIPES:    minecraft.NewPacketGenericCodec(PACKET_CLIENT_DECLARE_RECIPES, Swappers),
 	PACKET_CLIENT_TAGS:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_TAGS, Swappers),
+	PACKET_CLIENT_STOP_SOUND:         minecraft.NewPacketGenericCodec(PACKET_CLIENT_STOP_SOUND, Swappers),
 	// 1.14
 	PACKET_CLIENT_OPEN_HORSE_WINDOW:          minecraft.NewPacketGenericCodec(PACKET_CLIENT_OPEN_HORSE_WINDOW, Swappers),
 	PACKET_CLIENT_UPDATE_LIGHT:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_UPDATE_LIGHT, Swappers),
@@ -488,6 +489,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13
+	PacketClientStopSound: PACKET_CLIENT_STOP_SOUND,
 	// 1.14
 	PacketClientUpdateViewDistance: PACKET_CLIENT_UPDATE_VIEW_DISTANCE,
 	PacketClientEntitySoundEffect:  PACKET_CLIENT_ENTITY_SOUND_EFFECT,

--- a/packet/minecraft/v1162/constants.go
+++ b/packet/minecraft/v1162/constants.go
@@ -254,6 +254,7 @@ var PlayPacketServerCodec = packet.NewPacketCodecRegistryDual([]packet.PacketCod
 	PACKET_CLIENT_FACE_PLAYER:        minecraft.NewPacketGenericCodec(PACKET_CLIENT_FACE_PLAYER, Swappers),
 	PACKET_CLIENT_DECLARE_RECIPES:    minecraft.NewPacketGenericCodec(PACKET_CLIENT_DECLARE_RECIPES, Swappers),
 	PACKET_CLIENT_TAGS:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_TAGS, Swappers),
+	PACKET_CLIENT_STOP_SOUND:         minecraft.NewPacketGenericCodec(PACKET_CLIENT_STOP_SOUND, Swappers),
 	// 1.14
 	PACKET_CLIENT_OPEN_HORSE_WINDOW:          minecraft.NewPacketGenericCodec(PACKET_CLIENT_OPEN_HORSE_WINDOW, Swappers),
 	PACKET_CLIENT_UPDATE_LIGHT:               minecraft.NewPacketGenericCodec(PACKET_CLIENT_UPDATE_LIGHT, Swappers),
@@ -492,6 +493,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: PACKET_SERVER_PREPARE_CRAFTING_GRID,
 	PlayServerCraftingBookData:    PACKET_SERVER_CRAFTING_BOOK_DATA,
 	PlayServerAdvancementTab:      PACKET_SERVER_ADVANCEMENT_TAB,
+	// 1.13
+	PacketClientStopSound: PACKET_CLIENT_STOP_SOUND,
 	// 1.14
 	PacketClientUpdateViewDistance: PACKET_CLIENT_UPDATE_VIEW_DISTANCE,
 	PacketClientEntitySoundEffect:  PACKET_CLIENT_ENTITY_SOUND_EFFECT,

--- a/packet/minecraft/v18/constants.go
+++ b/packet/minecraft/v18/constants.go
@@ -394,6 +394,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: -1,
 	PlayServerCraftingBookData:    -1,
 	PlayServerAdvancementTab:      -1,
+	// 1.13 - unsupported
+	PacketClientStopSound: -1,
 	// 1.14 - unsupported
 	PacketClientUpdateViewDistance: -1,
 	PacketClientEntitySoundEffect:  -1,

--- a/packet/minecraft/v19/constants.go
+++ b/packet/minecraft/v19/constants.go
@@ -397,6 +397,8 @@ var IdMap = &minecraft.IdMap{
 	PlayServerPrepareCraftingGrid: -1,
 	PlayServerCraftingBookData:    -1,
 	PlayServerAdvancementTab:      -1,
+	// 1.13 - unsupported
+	PacketClientStopSound: -1,
 	// 1.14 - unsupported
 	PacketClientUpdateViewDistance: -1,
 	PacketClientEntitySoundEffect:  -1,


### PR DESCRIPTION
This resolves the player being kicked from the proxy when Player#stopSound is ran, due to: `use of closed network connection outBridgeErr: Decode, Packet Id does not have a codec: 82`