### PR TITLE
Make Mojang SessionServer Configurable

### DIFF
--- a/server/proxy/auth/constants.go
+++ b/server/proxy/auth/constants.go
@@ -1,5 +1,14 @@
 package auth
 
-const (
-	URL = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s"
+import (
+  "os"
 )
+
+var URL = "https://sessionserver.mojang.com/session/minecraft/hasJoined"
+
+func init() {
+  if value, ok := os.LookupEnv("LILYPAD_MOJANG_SESSIONSERVER_URL"); ok {
+    URL = value
+  }
+  URL = URL + "?username=%s&serverId=%s"
+}


### PR DESCRIPTION
Fixes issue #73 

This allows for server owners to configure their own mojang sessionserver for either a secondary authentication solution or a passthrough detection system for mojang authentication.